### PR TITLE
Adding standard A4 size frame in Landscape

### DIFF
--- a/SparkFun-Aesthetics.lbr
+++ b/SparkFun-Aesthetics.lbr
@@ -47599,6 +47599,28 @@ Two of these half tabs, rotated in opposite directions, can be connected togethe
 <text x="-1.016" y="3.556" size="1.778" layer="96">&gt;VALUE</text>
 <pin name="VCC" x="0" y="0" visible="off" length="short" direction="sup" rot="R90"/>
 </symbol>
+<symbol name="FR-A4L">
+<rectangle x1="178.7652" y1="0" x2="179.3748" y2="20.32" layer="94"/>
+<rectangle x1="225.7552" y1="-26.67" x2="226.3648" y2="67.31" layer="94" rot="R90"/>
+<wire x1="237.49" y1="0" x2="237.49" y2="5.08" width="0.1016" layer="94"/>
+<wire x1="237.49" y1="5.08" x2="273.05" y2="5.08" width="0.1016" layer="94"/>
+<wire x1="237.49" y1="5.08" x2="179.07" y2="5.08" width="0.1016" layer="94"/>
+<wire x1="179.07" y1="10.16" x2="237.49" y2="10.16" width="0.1016" layer="94"/>
+<wire x1="237.49" y1="10.16" x2="273.05" y2="10.16" width="0.1016" layer="94"/>
+<wire x1="179.07" y1="15.24" x2="273.05" y2="15.24" width="0.1016" layer="94"/>
+<wire x1="237.49" y1="5.08" x2="237.49" y2="10.16" width="0.1016" layer="94"/>
+<wire x1="179.07" y1="19.05" x2="179.07" y2="20.32" width="0.6096" layer="94"/>
+<wire x1="179.07" y1="20.32" x2="180.34" y2="20.32" width="0.6096" layer="94"/>
+<text x="181.61" y="11.43" size="2.54" layer="94" font="vector">&gt;DRAWING_NAME</text>
+<text x="181.61" y="6.35" size="2.286" layer="94" font="vector">&gt;LAST_DATE_TIME</text>
+<text x="195.58" y="1.27" size="2.54" layer="94" font="vector">&gt;SHEET</text>
+<text x="181.61" y="1.27" size="2.54" layer="94" font="vector">Sheet:</text>
+<text x="181.61" y="16.51" size="2.54" layer="94" font="vector">&gt;CNAME</text>
+<text x="238.76" y="1.27" size="2.54" layer="94" font="vector">Rev:</text>
+<text x="238.76" y="6.35" size="2.54" layer="94" font="vector">&gt;DESIGNER</text>
+<text x="248.92" y="1.27" size="2.54" layer="94" font="vector">&gt;CREVISION</text>
+<frame x1="-3.81" y1="-3.81" x2="276.86" y2="182.88" columns="8" rows="5" layer="94"/>
+</symbol>
 </symbols>
 <devicesets>
 <deviceset name="DGND" prefix="GND">
@@ -48248,6 +48270,21 @@ Standard 11x14 US Ledger frame</description>
 </gates>
 <devices>
 <device name="" package="SFE-NEW-WEBLOGO">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="FRAME-A4L">
+<description>&lt;b&gt;Schematic Frame&lt;/b&gt;
+&lt;br&gt;&lt;br&gt;
+Standard A4 size frame in Landscape</description>
+<gates>
+<gate name="G$1" symbol="FR-A4L" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
 <technologies>
 <technology name=""/>
 </technologies>


### PR DESCRIPTION
Easier to use multiple frames this way in a sheet (of a schematic) instead of copying and pasting.
