### PR TITLE
Bugfix: Decrease pad spacing of part to manufacturer recommendation

### DIFF
--- a/SparkFun-Electromechanical.lbr
+++ b/SparkFun-Electromechanical.lbr
@@ -9213,18 +9213,18 @@ Fits EVJY-00, EVJY-80, EVJY-81, EVJY-10, etc</description>
 <wire x1="-1.0922" y1="1.905" x2="-0.1778" y2="1.905" width="0.1778" layer="21"/>
 <wire x1="-0.1778" y1="-1.905" x2="-0.1778" y2="1.905" width="0.1778" layer="21"/>
 <wire x1="-0.1778" y1="-1.905" x2="-1.0922" y2="-1.905" width="0.1524" layer="21"/>
-<text x="-1.016" y="-4.191" size="1.016" layer="51" ratio="10">1</text>
+<text x="-1.016" y="-3.556" size="1.016" layer="51" ratio="10">1</text>
 <text x="-1.905" y="1.27" size="0.8128" layer="51" ratio="10">ON</text>
-<text x="0.254" y="-4.191" size="1.016" layer="51" ratio="10">2</text>
+<text x="0.254" y="-3.556" size="1.016" layer="51" ratio="10">2</text>
 <text x="-1.905" y="-6.096" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-2.032" y="5.334" size="1.27" layer="25" ratio="10">&gt;NAME</text>
 <rectangle x1="-0.889" y1="-0.381" x2="-0.381" y2="0" layer="21"/>
 <rectangle x1="-0.889" y1="-1.016" x2="-0.381" y2="-0.635" layer="21"/>
 <rectangle x1="-0.889" y1="-1.651" x2="-0.381" y2="-1.27" layer="21"/>
-<smd name="2" x="0.635" y="-3.7" dx="1.27" dy="0.762" layer="1" rot="R90"/>
-<smd name="1" x="-0.635" y="-3.7" dx="1.27" dy="0.762" layer="1" rot="R90"/>
-<smd name="4" x="-0.635" y="3.7" dx="1.27" dy="0.762" layer="1" rot="R90"/>
-<smd name="3" x="0.635" y="3.7" dx="1.27" dy="0.762" layer="1" rot="R90"/>
+<smd name="2" x="0.635" y="-3.075" dx="1.27" dy="0.762" layer="1" rot="R90"/>
+<smd name="1" x="-0.635" y="-3.075" dx="1.27" dy="0.762" layer="1" rot="R90"/>
+<smd name="4" x="-0.635" y="3.075" dx="1.27" dy="0.762" layer="1" rot="R90"/>
+<smd name="3" x="0.635" y="3.075" dx="1.27" dy="0.762" layer="1" rot="R90"/>
 <wire x1="0.1778" y1="1.905" x2="0.1778" y2="-1.905" width="0.1778" layer="21"/>
 <wire x1="0.1778" y1="1.905" x2="1.0922" y2="1.905" width="0.1778" layer="21"/>
 <wire x1="1.0922" y1="-1.905" x2="1.0922" y2="1.905" width="0.1778" layer="21"/>


### PR DESCRIPTION
Part DIPSWITCH-02-50MIL had pads too far away from each other, fix dimensions. See http://www.components.omron.com/components/web/PDFLIB.nsf/0/28CE18F108AB3F4785257201007DD6B3/$file/A6H_1110.pdf for details.
